### PR TITLE
Fix TypeScript global type resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "types": ["node", "jest", "multer"],
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
### Motivation
- Prevent TypeScript from implicitly loading every package under `node_modules/@types` (which caused `TS2688` errors like `babel__core 2`) by restricting the project-wide ambient types list.

### Description
- Add an explicit `compilerOptions.types` allowlist to `tsconfig.json` with `"node"`, `"jest"`, and `"multer"` so only necessary global type packages are loaded during development and tests.

### Testing
- Ran `npx tsc --noEmit -p tsconfig.json` and it completed successfully.
- Ran `npm run build` and the build completed successfully.
- Ran `timeout 15s npm run start:dev` and the Nest watch compilation started cleanly without the prior `TS2688` errors during the timed run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdbd5d3834833380476c9914935b50)